### PR TITLE
Implement a Redux workflow to get and set the server constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ A cross-platform mobile client for [Bassa](https://github.com/scorelab/Bassa)
 
  ## Known Issues
  - Socket.io connection between the Bassa-mobile app and Bassa-backend can have issues sometimes. Hence, functionalities that depend on the Socket.io connection such as Push Notifications, Download Progress Circle, Redux Refresh Handlers may not work sometimes.
+ - iOS version of the Bassa mobile app has not been tested.

--- a/app/actions/constantsActions.js
+++ b/app/actions/constantsActions.js
@@ -18,3 +18,24 @@ export const getKey = () => {
     type: constantsActions.GET_KEY,
   };
 };
+
+export const setHostUrl = url => {
+  return {
+    type: constantsActions.SET_HOST_URL,
+    payload: url,
+  };
+};
+
+export const setHostPort = port => {
+  return {
+    type: constantsActions.SET_HOST_PORT,
+    payload: port,
+  };
+};
+
+export const setKey = key => {
+  return {
+    type: constantsActions.SET_KEY,
+    payload: key,
+  };
+};

--- a/app/actions/constantsActions.js
+++ b/app/actions/constantsActions.js
@@ -1,0 +1,20 @@
+// @flow
+import { constantsActions } from './types';
+
+export const getHostUrl = () => {
+  return {
+    type: constantsActions.GET_HOST_URL,
+  };
+};
+
+export const getHostPort = () => {
+  return {
+    type: constantsActions.GET_HOST_PORT,
+  };
+};
+
+export const getKey = () => {
+  return {
+    type: constantsActions.GET_KEY,
+  };
+};

--- a/app/actions/types.js
+++ b/app/actions/types.js
@@ -30,4 +30,7 @@ export const constantsActions = {
   GET_HOST_URL: 'GET_HOST_URL',
   GET_HOST_PORT: 'GET_HOST_PORT',
   GET_KEY: 'GET_KEY',
+  SET_HOST_URL: 'SET_HOST_URL',
+  SET_HOST_PORT: 'SET_HOST_PORT',
+  SET_KEY: 'SET_KEY',
 };

--- a/app/actions/types.js
+++ b/app/actions/types.js
@@ -25,3 +25,9 @@ export const tokenActions = {
 export const downloadsActions = {
   UPDATE_LAST_DOWNLOAD_TIMESTAMP: 'UPDATE_LAST_DOWNLOAD_TIMESTAMP',
 };
+
+export const constantsActions = {
+  GET_HOST_URL: 'GET_HOST_URL',
+  GET_HOST_PORT: 'GET_HOST_PORT',
+  GET_KEY: 'GET_KEY',
+};

--- a/app/constants/API.js
+++ b/app/constants/API.js
@@ -1,3 +1,4 @@
+// TODO: Remove this, as APIConstants is available through Redux store
 const APIConstants = {
   HOST_URL: 'http://10.0.3.2',
   HOST_PORT: 5000,

--- a/app/reducers/constantsReducer.js
+++ b/app/reducers/constantsReducer.js
@@ -15,6 +15,21 @@ function constantsReducer(state = initialState, action) {
       return state.hostPort;
     case constantsActions.GET_KEY:
       return state.key;
+    case constantsActions.SET_HOST_URL:
+      return {
+        ...state,
+        hostUrl: action.payload,
+      };
+    case constantsActions.SET_HOST_PORT:
+      return {
+        ...state,
+        hostPort: action.payload,
+      };
+    case constantsActions.SET_KEY:
+      return {
+        ...state,
+        key: action.payload,
+      };
     default:
       return state;
   }

--- a/app/reducers/constantsReducer.js
+++ b/app/reducers/constantsReducer.js
@@ -1,0 +1,23 @@
+// @flow
+import { constantsActions } from '../actions/types';
+
+const initialState = {
+  hostUrl: 'http://10.0.3.2',
+  hostPort: 5000,
+  key: '123456789',
+};
+
+function constantsReducer(state = initialState, action) {
+  switch (action.type) {
+    case constantsActions.GET_HOST_URL:
+      return state.hostUrl;
+    case constantsActions.GET_HOST_PORT:
+      return state.hostPort;
+    case constantsActions.GET_KEY:
+      return state.key;
+    default:
+      return state;
+  }
+}
+
+export default constantsReducer;

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -5,6 +5,7 @@ import AppNavigator from '../containers/RootNavigator';
 import appReducer from './appReducer';
 import userReducer from './userReducer';
 import downloadsReducer from './downloadsReducer';
+import constantsReducer from './constantsReducer';
 
 const navReducer = createNavigationReducer(AppNavigator);
 
@@ -13,6 +14,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   nav: navReducer,
   downloads: downloadsReducer,
+  constants: constantsReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
## Fast Summary
This PR implements Redux workflow for Bassa server constants, as it was only stored in the plain `.js` file.
Now we'd be able to GET and SET the constants as the app run - it'll let the users set the URLs and PORTs (and eventually KEY) in UI, without changing the app's config 🎉