### PR TITLE
Implement Screens' Headers

### DIFF
--- a/app/containers/AboutScreen/index.js
+++ b/app/containers/AboutScreen/index.js
@@ -27,7 +27,7 @@ const HEIGHT: number = Dimensions.get('window').height;
 
 class AboutScreen extends Component {
   static navigationOptions = {
-    header: null,
+    title: 'About Bassa',
   };
 
   static propTypes = {

--- a/app/containers/RootNavigator.js
+++ b/app/containers/RootNavigator.js
@@ -1,11 +1,16 @@
 import React from 'react';
-import { createStackNavigator, createDrawerNavigator, createMaterialTopTabNavigator } from 'react-navigation';
+import {
+  createStackNavigator,
+  createDrawerNavigator,
+  createMaterialTopTabNavigator,
+} from 'react-navigation';
+import Icon from 'react-native-vector-icons/Ionicons'
 
 // root routes
 import Init from './Init';
 import SignIn from './SignIn';
 import SignUp from './SignUp';
-import AboutScreen from './AboutScreen'
+import AboutScreen from './AboutScreen';
 
 import CustomDrawer from './CustomDrawer';
 
@@ -29,30 +34,62 @@ const tabBarOptions = {
   scrollEnabled: false,
 };
 
-export const DownloadsTabs = createMaterialTopTabNavigator({
-  InProgressDownloads: { screen: InProgressDownloads },
-  CompletedDownloads: { screen: CompletedDownloads },
-
-}, {
+export const DownloadsTabs = createMaterialTopTabNavigator(
+  {
+    InProgressDownloads: { screen: InProgressDownloads },
+    CompletedDownloads: { screen: CompletedDownloads },
+  },
+  {
     initialRouteName: 'InProgressDownloads',
     swipeEnabled: false,
     tabBarOptions,
-  });
+  },
+);
 
-export const AccountsTabs = createMaterialTopTabNavigator({
-  Approvals: { screen: Approvals },
-  QuotaUsage: { screen: QuotaUsage },
-
-}, {
+export const AccountsTabs = createMaterialTopTabNavigator(
+  {
+    Approvals: { screen: Approvals },
+    QuotaUsage: { screen: QuotaUsage },
+  },
+  {
     initialRouteName: 'Approvals',
     swipeEnabled: false,
     tabBarOptions,
-  });
+  },
+);
+
+const createStackForDrawer = (stackName, screen, headerTitle) =>
+  createStackNavigator(
+    {
+      [stackName]: { screen },
+    },
+    {
+      navigationOptions: ({ navigation }) => ({
+        // If unspecified, fall back to default navigationOptions' title (set in Component)
+        title: headerTitle || undefined,
+        headerLeft: <Icon
+          name="md-menu"
+          style={{ color: '#FFF', fontSize: 35, marginLeft: 20 }}
+          onPress={() => navigation.openDrawer()}
+        />,
+        headerStyle: {
+          backgroundColor: theme.PRIMARY_COLOR,
+          elevation: 0,
+        },
+        headerTintColor: theme.TEXT_COLOR_INVERT,
+      }),
+    },
+  );
 
 const Drawer = createDrawerNavigator(
   {
-    Downloads: { screen: DownloadsTabs },
-    Accounts: { screen: AccountsTabs },
+    Downloads: {
+      screen: createStackForDrawer('Downloads', DownloadsTabs, 'Downloads'),
+    },
+    Accounts: createStackForDrawer('Accounts', AccountsTabs, 'Accounts'),
+    About: {
+      screen: createStackForDrawer('About', AboutScreen),
+    },
   },
   {
     contentComponent: props => <CustomDrawer {...props} />,
@@ -63,7 +100,6 @@ const AppNavigator = createStackNavigator({
   Init: { screen: Init },
   SignIn: { screen: SignIn },
   SignUp: { screen: SignUp },
-  About: { screen: AboutScreen },
   MainDrawer: { screen: Drawer, navigationOptions: { header: null } },
 });
 


### PR DESCRIPTION
## Fast Summary
I've added the **Headers** with corresponding titles to all screens. However, I must've come up with an idea on how to display titles on the screens which are used in the `Drawer` (they were clashing with each other because Drawer itself doesn't implement the **Header** component). To achieve this I created a helper function which creates Stacks for given screens so that all Screens accessed by `Drawer` can display **Headers** (this is more DRY than creating all the Stacks by hand)

Screenshots:
<img src="https://user-images.githubusercontent.com/25536472/48316597-21605400-e5e6-11e8-9c0d-37d868ae988b.jpg" alt="Downloads" width="40%" />
<img src="https://user-images.githubusercontent.com/25536472/48316607-3c32c880-e5e6-11e8-8c21-63a73a9fc56e.jpg" alt="Accounts" width="40%" />
<img src="https://user-images.githubusercontent.com/25536472/48316611-4ce33e80-e5e6-11e8-8d35-0e4344c59fd5.jpg" alt="About" width="40%" />

---
I believe that this can be improved, so I'm waiting for all the suggestions ⌚️.
